### PR TITLE
Added requirement of python-bluez

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pygame) removed. I'm pretty sure it only works on Linux.
 
 To run `gr8webupd8m8`, you need:
 * Linux.
-* The `bluez-tools` package.
+* The `bluez-tools` package (you might need to install also `python-bluez`).
 * Bluetooth.
 
 ## Usage


### PR DESCRIPTION
Without the package `python-bluez` it outputs this error:

```
Traceback (most recent call last):
  File "./gr8w8upd8m8.py", line 5, in <module>
    import bluetooth
ImportError: No module named bluetooth
```
